### PR TITLE
Add UserAgent parameter in constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ const productsParser = new Json2csvParser({
 const reviewsParser = new Json2csvParser({ fields: ['id', 'review_data', 'name', 'rating', 'title', 'review'] });
 
 class AmazonScraper extends EventEmitter {
-    constructor({ keyword, number, sponsored, proxy, cli, save, scrapeType, asin, sort, discount, host, event, rating = [1, 5] }) {
+    constructor({ keyword, number, sponsored, proxy, cli, save, scrapeType, asin, sort, discount, host, event, rating = [1, 5], ua }) {
         super();
         this._mainHost = `https://${host || 'www.amazon.com'}`;
         this._cookieJar = jar();
@@ -41,6 +41,7 @@ class AmazonScraper extends EventEmitter {
         this._rating = rating;
         this._minRating = 1;
         this._maxRating = 5;
+        this.ua = ua || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36';
     }
 
     // Main request
@@ -54,7 +55,7 @@ class AmazonScraper extends EventEmitter {
                     ...(body ? { body } : {}),
                     ...(form ? { form } : {}),
                     headers: {
-                        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:69.0) Gecko/20100101 Firefox/69.0',
+                        'user-agent': this.ua,
                         ...headers,
                         accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
                         'accept-language': 'en-US,en;q=0.5',


### PR DESCRIPTION
I realize that Amazon starts to block the scraper as early as the first 5 products (at least for me when I first started using this library). Changing the UA allows the scraper to circumvent the detection at least a little bit longer (works for more than 20+ products with 100 reviews each).