### PR TITLE
Fix infinite loop on reviews

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -292,6 +292,12 @@ class AmazonScraper extends EventEmitter {
                 continue;
             }
         }
+        
+        if (Object.keys(scrapingResult).length < 1) {
+            this._continue = false;
+            return;
+        }
+        
         for (let key in scrapingResult) {
             if (this._event) {
                 let item = this._validateRating(scrapingResult[key]);


### PR DESCRIPTION
On products that have less than X number of reviews (for example, I want 100 reviews but there is only 8), review scraper seems to go on an infinite loop since the criteria is not met. This will stop the scraping and return the result as soon as no reviews are found.

 I have tried it on multiple products on my main project. This is a sample product to test it out on.
```javascript
let reviews = await amazon.reviews({
        asin: "B083SB6RHQ",
        number: 100
    });
```

Requested 100, but should only return 4.